### PR TITLE
Correct path to ruby version of rmate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/aurora/rmate.git
 [submodule "rmate-ruby"]
 	path = rmate-ruby
-	url = https://github.com/avian/rmate.git
+	url = https://github.com/textmate/rmate.git


### PR DESCRIPTION
TextMate went open source, and as a result, its repositories have moved. This fixes that.
