### PR TITLE
Split display name at colon before generating temporary file name

### DIFF
--- a/rsub.py
+++ b/rsub.py
@@ -96,7 +96,7 @@ class Session:
         except OSError as e:
             sublime.error_message('Failed to create rsub temporary directory! Error: %s' % e)
             return
-        self.temp_path = os.path.join(self.temp_dir, os.path.basename(self.env['display-name']))
+        self.temp_path = os.path.join(self.temp_dir, os.path.basename(self.env['display-name'].split(':')[-1]))
         try:
             temp_file = open(self.temp_path, "w+")
             temp_file.write(self.file[:self.file_size])


### PR DESCRIPTION
This fixes an issue which occurs under the following circumstances:
- Sublime Text is installed on a Windows machine.
- On the remote system, rmate is called using a filename from the current working directory.

In this scenario, the display name generated by rmate is of the form "hostname:filename"; because there are no slashes to split on, the temporary file name which is generated is "hostname:filename", not just "filename". The resulting filename is invalid on Windows, and it is impossible to update the file as a result.
