### PR TITLE
Feature/45 does not open new tab for already opened file

### DIFF
--- a/rsub.py
+++ b/rsub.py
@@ -34,7 +34,7 @@ class Session:
         self.in_file = False
         self.parse_done = False
         self.socket = socket
-        self.temp_path = None
+        self.temp_file = None
 
     # http://www.jacobtomlinson.co.uk/2014/02/16/python-script-recursively-remove-empty-folders-directories/
     def removeEmptyFolders( self, path, removeRoot=True ):
@@ -92,13 +92,13 @@ class Session:
         self.socket.send(b"\n")
         self.socket.shutdown(socket.SHUT_RDWR)
         self.socket.close()
-        os.unlink(self.temp_path)
+        os.unlink(self.temp_file)
         os.rmdir(self.temp_dir)
 
     def send_save(self):
         self.socket.send(b"save\n")
         self.socket.send(b"token: " + self.env['token'].encode("utf8") + b"\n")
-        temp_file = open(self.temp_path, "rb")
+        temp_file = open(self.temp_file, "rb")
         new_file = temp_file.read()
         temp_file.close()
         self.socket.send(b"data: " + str(len(new_file)).encode("utf8") + b"\n")
@@ -114,17 +114,17 @@ class Session:
         except OSError as e:
             sublime.error_message('Failed to create rsub temporary directory! Error: %s' % e)
             return
-        self.temp_path = os.path.join(self.temp_dir,
+        self.temp_file = os.path.join(self.temp_dir,
                                       os.path.basename(self.env['display-name'].split(':')[-1]))
         try:
-            temp_file = open(self.temp_path, "wb+")
+            temp_file = open( self.temp_file, "wb+" )
             temp_file.write(self.file[:self.file_size])
             temp_file.flush()
             temp_file.close()
         except IOError as e:
             # Remove the file if it exists.
-            if os.path.exists(self.temp_path):
-                os.remove(self.temp_path)
+            if os.path.exists( self.temp_file ):
+                os.remove( self.temp_file )
             try:
                 os.rmdir(self.temp_dir)
             except OSError:
@@ -137,7 +137,7 @@ class Session:
             sublime.run_command("new_window")
 
         # Open it within sublime
-        view = sublime.active_window().open_file(self.temp_path)
+        view = sublime.active_window().open_file( self.temp_file )
 
         # Add the file metadata to the view's settings
         # This is mostly useful to obtain the path of this file on the server

--- a/rsub.py
+++ b/rsub.py
@@ -95,7 +95,11 @@ class Session:
         self.socket.shutdown(socket.SHUT_RDWR)
         self.socket.close()
         os.unlink(self.temp_file)
-        os.rmdir(WORKDIR)
+        try:
+            self.removeEmptyFolders( WORKDIR, True )
+        except OSError as e:
+            sublime.error_message( 'Can not clean WORKDIR: %s' % e )
+
 
     def send_save(self):
         self.socket.send(b"save\n")
@@ -129,9 +133,9 @@ class Session:
             if os.path.exists( self.temp_file ):
                 os.remove( self.temp_file )
             try:
-                os.rmdir(WORKDIR)
-            except OSError:
-                pass
+                self.removeEmptyFolders( self.temp_dir )
+             except OSError as e:
+                 sublime.error_message( 'Can not clean WORKDIR: %s' % e )
 
             sublime.error_message('Failed to write to temp file! Error: %s' % str(e))
 

--- a/rsub.py
+++ b/rsub.py
@@ -126,8 +126,10 @@ class Session:
         except OSError as e:
             sublime.error_message('Failed to create rsub temporary directory! Error: %s' % e)
             return
-        self.temp_file = os.path.join(self.temp_dir,
-                                      os.path.basename(self.env['display-name'].split(':')[-1]))
+        self.temp_file =  os.path.join(
+            self.temp_dir,
+            os.path.basename( self.env['display-name'].split(':')[-1] )
+        )
         try:
             temp_file = open( self.temp_file, "wb+" )
             temp_file.write(self.file[:self.file_size])

--- a/rsub.py
+++ b/rsub.py
@@ -116,8 +116,13 @@ class Session:
         # Create a secure temporary directory, both for privacy and to allow
         # multiple files with the same basename to be edited at once without
         # overwriting each other.
+
+        self.env['host'] =  self.env['display-name'].split(':')[0]
+        self.temp_dir =  WORKDIR +"/" +self.env['host'] +os.path.dirname( self.env['real-path'] )
+
         try:
-            self.temp_dir = WORKDIR
+            if not os.path.exists( self.temp_dir ) :
+                os.makedirs( self.temp_dir )
         except OSError as e:
             sublime.error_message('Failed to create rsub temporary directory! Error: %s' % e)
             return

--- a/rsub.py
+++ b/rsub.py
@@ -36,6 +36,27 @@ class Session:
         self.socket = socket
         self.temp_path = None
 
+    # http://www.jacobtomlinson.co.uk/2014/02/16/python-script-recursively-remove-empty-folders-directories/
+    def removeEmptyFolders( self, path, removeRoot=True ):
+        'Function to remove empty folders'
+        if not os.path.isdir(path):
+            return
+
+        # remove empty subfolders
+        files = os.listdir(path)
+        if len(files):
+            for f in files:
+                fullpath = os.path.join(path, f)
+                if os.path.isdir(fullpath):
+                    self.removeEmptyFolders(fullpath)
+
+        # if folder empty, delete it
+        files = os.listdir(path)
+        if len(files) == 0 and removeRoot:
+            print( "Removing empty folder:", path )
+            os.rmdir(path)
+
+
     def parse_input(self, input_line):
         if (input_line.strip() == b"open" or self.parse_done is True):
             return

--- a/ssh-copy-rsub
+++ b/ssh-copy-rsub
@@ -3,11 +3,6 @@
 # Shell script to install rsub on the remove server so we can open shell scripts locally.
 # Author: Leon Radley (http://github.com/leon)
 
-if [ -z "$INSTALL_PREFIX" ] ; then
-    INSTALL_PREFIX="/usr/local/bin"
-fi
-
-
 URL="https://raw.github.com/textmate/rmate/master/rmate"
 
 if [ "$#" -gt 1 ] || [ "$1" = "-b" ] || [ "$1" = "--bash" ]; then
@@ -19,9 +14,6 @@ if [ "$#" -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
 
 cat <<EOF
 Usage: $0 [--bash] [user@]machine
-Environment:
-   INSTALL_PREFIX=$INSTALL_PREFIX
-
 
 # Install Sublime Text plugin
 https://github.com/henrikpersson/rsub
@@ -44,7 +36,7 @@ EOF
 exit 1
 fi
 
-wget --quiet -O - "${URL}" | ssh ${1%:} "umask 077; test -d $INSTALL_PREFIX || mkdir -p $INSTALL_PREFIX; cat > $INSTALL_PREFIX/rsub; chmod a+rx $INSTALL_PREFIX/rsub" || exit 1
+wget --quiet -O - "${URL}" | ssh ${1%:} 'umask 077; test -d /usr/local/bin || mkdir -p /usr/local/bin; cat > /usr/local/bin/rsub; chmod a+rx /usr/local/bin/rsub' || exit 1
 
 cat <<EOF
 

--- a/ssh-copy-rsub
+++ b/ssh-copy-rsub
@@ -3,6 +3,11 @@
 # Shell script to install rsub on the remove server so we can open shell scripts locally.
 # Author: Leon Radley (http://github.com/leon)
 
+if [ -z "$INSTALL_PREFIX" ] ; then
+    INSTALL_PREFIX="/usr/local/bin"
+fi
+
+
 URL="https://raw.github.com/textmate/rmate/master/rmate"
 
 if [ "$#" -gt 1 ] || [ "$1" = "-b" ] || [ "$1" = "--bash" ]; then
@@ -14,6 +19,9 @@ if [ "$#" -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
 
 cat <<EOF
 Usage: $0 [--bash] [user@]machine
+Environment:
+   INSTALL_PREFIX=$INSTALL_PREFIX
+
 
 # Install Sublime Text plugin
 https://github.com/henrikpersson/rsub
@@ -36,7 +44,7 @@ EOF
 exit 1
 fi
 
-wget --quiet -O - "${URL}" | ssh ${1%:} 'umask 077; test -d /usr/local/bin || mkdir -p /usr/local/bin; cat > /usr/local/bin/rsub; chmod a+rx /usr/local/bin/rsub' || exit 1
+wget --quiet -O - "${URL}" | ssh ${1%:} "umask 077; test -d $INSTALL_PREFIX || mkdir -p $INSTALL_PREFIX; cat > $INSTALL_PREFIX/rsub; chmod a+rx $INSTALL_PREFIX/rsub" || exit 1
 
 cat <<EOF
 


### PR DESCRIPTION
This patch closes [this](https://github.com/henrikpersson/rsub/issues/45)
Now, if you try to open same file twice the old 'tab' will be brought to front

Because of same directory tree structure is created localy under tmp directory we can see nice hints on tabs. So this patch close [that](https://github.com/henrikpersson/rsub/issues/46) issue too

![tab1](http://i.piccy.info/i9/0f0b2981ec646f9e8e90fcc9330f6925/1442826796/10944/880124/rsub_bug_fix1.png)

![tab2](http://i.piccy.info/i9/71709e2bc00c28509d08d92e05a7b4e8/1442826838/15435/880124/rsub_bug_fix2.png)