### PR TITLE
added support for moving caret option '--line'

### DIFF
--- a/rsub.py
+++ b/rsub.py
@@ -116,7 +116,10 @@ class Session:
             sublime.run_command("new_window")
 
         # Open it within sublime
-        view = sublime.active_window().open_file(self.temp_path)
+        view = sublime.active_window().open_file(
+            "{0}:{1}:0".format(
+                self.temp_path, self.env['selection'] if 'selection' in self.env else 0),
+            sublime.ENCODED_POSITION)
 
         # Add the file metadata to the view's settings
         # This is mostly useful to obtain the path of this file on the server


### PR DESCRIPTION
Hello, 

i am the author of the bash port of rmate and it was brought to my attention ( aurora/rsub#47 ), that the `--line` option of rmate does not work when using it with sublime text. In my opinion this is an issue in rsub not supporting the 'selection' property of the rmate protocol. I've developed a little patch which makes this possible.

I would be happy if you would consider to apply this to rsub, thanks!